### PR TITLE
Add default value for missing rtn on full_proc

### DIFF
--- a/xontrib/powerline2.xsh
+++ b/xontrib/powerline2.xsh
@@ -178,7 +178,7 @@ def full_proc(sample=False):
     if __xonsh__.history.buffer:
         lst = __xonsh__.history.buffer[-1]
         color = $PL_COLORS['full_proc'][1] if lst['rtn'] != 0 else $PL_COLORS['full_proc'][2]
-        value = ' rtn: %d ts: %.2fs ' % (lst['rtn'], lst['ts'][1] - lst['ts'][0])
+        value = ' rtn: %d ts: %.2fs ' % (lst['rtn'] or -1, lst['ts'][1] - lst['ts'][0])
         return Section(value, $PL_COLORS['full_proc'][0], color)
 
 


### PR DESCRIPTION
When the executed command doesn't have an rtn value, the plugin crash. This commit adds a default value (-1) for those commands and prevents this failure.

Closes https://github.com/vaaaaanquish/xontrib-powerline2/issues/10 