### PR TITLE
#13 Fix problem with weird character on multiline prompt

### DIFF
--- a/xontrib/powerline2.xsh
+++ b/xontrib/powerline2.xsh
@@ -291,6 +291,6 @@ def pl_build_prompt():
     $BOTTOM_TOOLBAR = prompt_builder($PL_TOOLBAR)
     $RIGHT_PROMPT = prompt_builder($PL_RPROMPT, True)
     $TITLE = '{current_job:{} | }{cwd_base} | {user}@{hostname}'
-    $MULTILINE_PROMPT = '»'
+    $MULTILINE_PROMPT = '»' if 'MULTILINE_PROMPT' not in ${...} else $MULTILINE_PROMPT
 
 pl_build_prompt()

--- a/xontrib/powerline2.xsh
+++ b/xontrib/powerline2.xsh
@@ -291,6 +291,6 @@ def pl_build_prompt():
     $BOTTOM_TOOLBAR = prompt_builder($PL_TOOLBAR)
     $RIGHT_PROMPT = prompt_builder($PL_RPROMPT, True)
     $TITLE = '{current_job:{} | }{cwd_base} | {user}@{hostname}'
-    $MULTILINE_PROMPT = ''
+    $MULTILINE_PROMPT = '»'
 
 pl_build_prompt()


### PR DESCRIPTION
Closes https://github.com/vaaaaanquish/xontrib-powerline2/issues/13

Hello there,

While using powerline2 I've experienced that the multiline used symbol looks pretty bad in some terminal emulators, for example in terminator.