### PR TITLE
Add try/except to prevent error if the lambda return None

### DIFF
--- a/xontrib/powerline2.xsh
+++ b/xontrib/powerline2.xsh
@@ -212,17 +212,20 @@ def prompt_builder(var, right=False, sample=False):
             p = []
             sections = []
             for s in pre_sections:
-                if type(s()) == list:
-                    s = Section(*s())
-                if isinstance(s, Section):
-                    sections.append(s)
-                else:
-                    r = s(sample)
-                    if r is not None:
-                        if type(r) == list:
-                            sections += r
-                        else:
-                            sections.append(r)
+                try:
+                    if type(s()) == list:
+                        s = Section(*s())
+                    if isinstance(s, Section):
+                        sections.append(s)
+                    else:
+                        r = s(sample)
+                        if r is not None:
+                            if type(r) == list:
+                                sections += r
+                            else:
+                                sections.append(r)
+                except:
+                    pass
 
             size = len(sections)
             for i, sec in enumerate(sections):


### PR DESCRIPTION
This is useful to create conditional sections that may return None:

```python
$PL_EXTRA_SEC = {
    "user": lambda: [
                    f"   {username} ",
                    "WHITE",
                    "#00106d"
                ],
    "git_hash": lambda: [
                    f" {_git_hash()} ",
                    "BLACK",
                    "#cf8e00"
                ] if _git_hash() else None
}
```